### PR TITLE
make link to desk.js correct

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 == deck.js Backend for Asciidoctor
 
-The https://github.com/asciidoctor/asciidoctor-deck.js[deck.js backend] is a collection of Haml templates for https://github.com/asciidoctor/asciidoctor[Asciidoctor] that transform an AsciiDoc document into HTML5 slides animated by http://lab.hakim.se/deck.js/[deck.js].
+The https://github.com/asciidoctor/asciidoctor-deck.js[deck.js backend] is a collection of Haml templates for https://github.com/asciidoctor/asciidoctor[Asciidoctor] that transform an AsciiDoc document into HTML5 slides animated by http://imakewebthings.com/deck.js/[deck.js].
 
 //image:https://travis-ci.org/asciidoctor/asciidoctor-deck.js.svg?branch=master[Build Status,link=https://travis-ci.org/asciidoctor/asciidoctor-deck.js]
 


### PR DESCRIPTION
- was pointing at http://lab.hakim.se/deck.js/ - which is 404, and hakim.se is the author of reveal.js
